### PR TITLE
Update Autodesk.AddInManager.addin

### DIFF
--- a/SDK/Add-In Manager/Autodesk.AddInManager.addin
+++ b/SDK/Add-In Manager/Autodesk.AddInManager.addin
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RevitAddIns>
    <AddIn Type="Command">
-      <Assembly>[TARGETDIR]Autodesk.AddInManager.Command.dll</Assembly>
+      <Assembly>Autodesk.AddInManager.Command.dll</Assembly>
       <ClientId>8C0A9E25-B7C5-421c-A1AB-702F73FA551F</ClientId>
       <FullClassName>AddInManager.CAddInManager</FullClassName>
       <Text>Add-In Manager (Manual Mode)</Text>
@@ -11,7 +11,7 @@
       <VendorDescription><![CDATA[https://knowledge.autodesk.com/search?search=AddInManager&sort=score]]></VendorDescription>
   </AddIn>
   <AddIn Type="Command">
-      <Assembly>[TARGETDIR]Autodesk.AddInManager.Command.dll</Assembly>
+      <Assembly>Autodesk.AddInManager.Command.dll</Assembly>
       <ClientId>6FDB8EC7-CCD3-4fc0-ADB7-B459D298FB93</ClientId>
       <FullClassName>AddInManager.CAddInManagerFaceless</FullClassName>
       <Text>Add-In Manager (Manual Mode, Faceless)</Text>
@@ -21,7 +21,7 @@
       <VendorDescription><![CDATA[https://knowledge.autodesk.com/search?search=AddInManager&sort=score]]></VendorDescription>
   </AddIn>
   <AddIn Type="Command">
-      <Assembly>[TARGETDIR]Autodesk.AddInManager.Command.dll</Assembly>
+      <Assembly>Autodesk.AddInManager.Command.dll</Assembly>
       <ClientId>91A2419C-5FCA-491A-BAA3-29A497EC07C7</ClientId>
       <FullClassName>AddInManager.CAddInManagerReadOnly</FullClassName>
       <Text>Add-In Manager (ReadOnly Mode)</Text>


### PR DESCRIPTION
Removing "[TARGETDIR]" from .addin file, Revit was throwing an error, can't load "Add-in manager" "Assembly" not found.
This has been annoying me since Revit 2019. =)